### PR TITLE
feat: Possibly fixed some of the failing tests in CI pipeline

### DIFF
--- a/.github/workflows/scaffy.yml
+++ b/.github/workflows/scaffy.yml
@@ -26,4 +26,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      - run: npm test
+      - run: npm run test:ci

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run test:silent

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jest": "^26.1.1",
-        "husky": "^7.0.4",
         "jest": "^27.5.1",
         "prettier": "^2.5.1",
         "ts-import-patch": "github:OlaoluwaM/ts-import-patch#main",
@@ -3506,21 +3505,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -9364,12 +9348,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
-    "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11240,7 +11218,7 @@
     "ts-import-patch": {
       "version": "git+ssh://git@github.com/OlaoluwaM/ts-import-patch.git#841f2811512a3ea2b61bf3642cef1624086779de",
       "dev": true,
-      "from": "ts-import-patch@OlaoluwaM/ts-import-patch#main",
+      "from": "ts-import-patch@github:OlaoluwaM/ts-import-patch#main",
       "requires": {
         "@types/chalk": "^2.2.0",
         "@types/globby": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postbuild": "ts-import-patch ./dist",
     "test:setup": "./setup-test-data/setup.sh",
     "test": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:ci": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules CI=true jest",
     "test:coverage": "npm run test -- --coverage",
     "test:silent": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --silent",
     "test:single": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern --",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "test:coverage": "npm run test -- --coverage",
     "test:silent": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --silent",
     "test:single": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern --",
-    "test:single:silent": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --silent --testPathPattern --",
-    "prepare": "husky install"
+    "test:single:silent": "npm run test:setup && NODE_OPTIONS=--experimental-vm-modules jest --silent --testPathPattern --"
   },
   "keywords": [],
   "author": "Olaoluwa Mustapha <jomeemustapha@gmail.com>",
@@ -39,7 +38,6 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.1",
-    "husky": "^7.0.4",
     "jest": "^27.5.1",
     "prettier": "^2.5.1",
     "ts-import-patch": "github:OlaoluwaM/ts-import-patch#main",

--- a/src/app/downloadFile.ts
+++ b/src/app/downloadFile.ts
@@ -6,7 +6,7 @@ import { error, info, isEmpty, success, toMultiLineString } from '../utils';
 
 const { IS_TEST = false } = process.env;
 const MAX_TIMEOUT_FOR_DOWNLOAD = IS_TEST ? 5 : 300;
-const MAX_RETRIES_FOR_DOWNLOAD = IS_TEST ? 3 : 20;
+const MAX_RETRIES_FOR_DOWNLOAD = IS_TEST ? 1 : 20;
 
 enum CurlOrWget {
   Curl = 'curl',

--- a/src/app/downloadFile.ts
+++ b/src/app/downloadFile.ts
@@ -6,6 +6,7 @@ import { error, info, isEmpty, success, toMultiLineString } from '../utils';
 
 const { IS_TEST = false } = process.env;
 const MAX_TIMEOUT_FOR_DOWNLOAD = IS_TEST ? 5 : 300;
+const MAX_RETRIES_FOR_DOWNLOAD = IS_TEST ? 3 : 20;
 
 enum CurlOrWget {
   Curl = 'curl',
@@ -77,7 +78,7 @@ async function downloadWithWget(urls: string[], destinationDir = '.'): Promise<v
   );
 
   try {
-    await $`wget -T ${MAX_TIMEOUT_FOR_DOWNLOAD} -i ${WGET_URL_LIST_FILE_PATH} -P ${destinationDir} 1>/dev/null`;
+    await $`wget --tries=${MAX_RETRIES_FOR_DOWNLOAD} -T ${MAX_TIMEOUT_FOR_DOWNLOAD} -i ${WGET_URL_LIST_FILE_PATH} -P ${destinationDir} 1>/dev/null`;
   } catch (processError) {
     error(`Error Downloading with wget: ${(processError as ProcessOutput).stderr}\n`);
   } finally {

--- a/src/app/downloadFile.ts
+++ b/src/app/downloadFile.ts
@@ -61,6 +61,9 @@ async function downloadWithCurl(urls: string[], destinationDir = '.') {
         (processErr as ProcessOutput).stderr
       }`
     );
+
+    info('Retrying download with wget...');
+    await downloadWithWget(urls, destinationDir);
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,15 @@
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-export const __dirname = dirname(__filename);
+// This isn't in the `utils` file to avoid a cyclic dependency error
+export function getAbsolutePathsForFile(fileUrl: string) {
+  const __filename = fileURLToPath(fileUrl);
+  const __dirname = dirname(__filename);
+
+  return { __dirname, __filename };
+}
+
+export const { __dirname } = getAbsolutePathsForFile(import.meta.url);
 
 export const SCAFFY_CONFIG_GLOB = '**/*scaffy.json';
 export const ERROR_HOOK = 'Error Occurred' as const;

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -3,7 +3,6 @@ import prompt from 'prompts';
 import download from '../src/app/downloadFile';
 
 import { ExitCodes } from '../src/constants';
-import { testDataDir } from './test-setup';
 import { ConfigEntry } from '../src/compiler/types';
 import { fs as fsExtra } from 'zx';
 import { ObjectValidator } from '../src/lib/schema-validator';
@@ -38,10 +37,7 @@ describe('Tests for CLI arguments parsing', () => {
       {
         command: 'rm',
         tools: ['react', '@babel/core', 'typescript'],
-        pathToScaffyConfig: path.relative(
-          './',
-          `${testDataDir}/local-configs/test.scaffy.json`
-        ),
+        pathToScaffyConfig: path.relative('./', `./local-configs/test.scaffy.json`),
       },
     ],
     [
@@ -185,7 +181,7 @@ describe('Tests for downloading remote configuration', () => {
   ];
 
   const SUB_TEST_DIR_FOR_TEST = 'for-remote-downloads' as const;
-  const destinationDir = `${testDataDir}/${SUB_TEST_DIR_FOR_TEST}`;
+  const destinationDir = `./${SUB_TEST_DIR_FOR_TEST}`;
 
   beforeEach(async () => {
     await fsExtra.emptyDir(destinationDir);
@@ -207,7 +203,6 @@ describe('Tests for downloading remote configuration', () => {
     }
   );
 
-  // TODO: fails on initial run
   test.each([['curl'], ['wget'], ['no specified command']])(
     'Should make sure that remote configs can be downloaded even if some cannot be downloaded using %s',
     async curlOrWget => {
@@ -224,7 +219,7 @@ describe('Tests for downloading remote configuration', () => {
         destinationDir
       );
 
-      const successfulPromises = isSuccessfulPromise
+      const successfulPromises = isSuccessfulPromise;
       const numberOfRemoteConfigsDownload =
         remoteConfigsDownloadStatuses.filter(successfulPromises).length;
 
@@ -235,7 +230,7 @@ describe('Tests for downloading remote configuration', () => {
 });
 
 describe('Tests for scaffy schema parsing', () => {
-  const configDir = `${testDataDir}/other-data`;
+  const configDir = `./other-data`;
 
   test('That parser succeeds with valid config file ', async () => {
     // Arrange

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -3,22 +3,27 @@ import bootstrap from '../src/cmds/bootstrap';
 import parseScaffyConfig from '../src/app/parseConfig';
 
 import { ExitCodes } from '../src/constants';
-import { testDataDir } from './test-setup';
 import { parseProjectDependencies } from '../src/app/helpers';
 import { ConfigEntry, ConfigSchema } from '../src/compiler/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test, expect, beforeAll, jest } from '@jest/globals';
 import { doAllFilesExist, isSuccessfulPromise, didAllPromisesSucceed } from './helpers';
-import { extractBasenameFromPath, isEmpty, isSubset, pickObjPropsToAnotherObj } from '../src/utils';
+import {
+  isEmpty,
+  isSubset,
+  extractBasenameFromPath,
+  pickObjPropsToAnotherObj,
+} from '../src/utils';
 
-const testingDir = `${testDataDir}/for-bootstrap-cmd`;
 const pathToScaffyConfig = `./sample.scaffy.json`;
 
 let toolNamesInConfig: string[];
 let sampleScaffyConfig: ConfigSchema;
 
 beforeAll(async () => {
+  const testingDir = `./for-bootstrap-cmd`;
   process.chdir(testingDir);
+
   sampleScaffyConfig = await parseScaffyConfig(pathToScaffyConfig);
   toolNamesInConfig = Object.keys(sampleScaffyConfig);
 });

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -21,7 +21,6 @@ let toolNamesInConfig: string[];
 let sampleScaffyConfig: ConfigSchema;
 
 beforeAll(async () => {
-  console.log({ t: process.cwd() });
   const testingDir = `./for-bootstrap-cmd`;
   process.chdir(testingDir);
 

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -21,6 +21,7 @@ let toolNamesInConfig: string[];
 let sampleScaffyConfig: ConfigSchema;
 
 beforeAll(async () => {
+  console.log({ t: process.cwd() });
   const testingDir = `./for-bootstrap-cmd`;
   process.chdir(testingDir);
 

--- a/tests/learning/zx.test.ts
+++ b/tests/learning/zx.test.ts
@@ -1,9 +1,12 @@
-import path from 'path';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test, expect } from '@jest/globals';
 import { doesPathExist } from '../../src/app/helpers';
 import { $, ProcessOutput } from 'zx';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test, expect, beforeAll } from '@jest/globals';
+
+beforeAll(() => {
+  const LEARNING_TESTS_DATA_DIR = './for-learning';
+  process.chdir(LEARNING_TESTS_DATA_DIR);
+});
 
 async function commandWithDynamicFlags(flags: string[] = []): Promise<ProcessOutput> {
   // Using `ls` here because it does not error out when called with no args or flags
@@ -19,18 +22,10 @@ test.each([
 });
 
 test('Should check how files are deleted in zx', async () => {
-  // Arrange
-  const testDir = path.resolve('tests', './test-data/for-learning/');
-
   // Act
-  await $`touch ${testDir}/example.txt`;
+  await $`touch ./example.txt`;
+  await $`rm ./example.txt`;
 
   // Assert
-  expect(await doesPathExist(`${testDir}/example.txt`)).toBe(true);
-
-  // Act
-  await $`rm -rf ${testDir}/*`;
-
-  // Assert
-  expect(await doesPathExist(`${testDir}/example.txt`)).toBe(false);
+  expect(await doesPathExist(`./example.txt`)).toBe(false);
 });

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -1,6 +1,14 @@
-import { $ } from 'zx';
 import path from 'path';
+import { $ } from 'zx';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { beforeAll } from '@jest/globals';
 
 $.verbose = true;
 process.env.IS_TEST = 'true';
-export const testDataDir = path.resolve('tests', './test-data/');
+
+const testDataDir = path.resolve('tests', './test-data/');
+
+beforeAll(() => {
+  process.chdir(testDataDir);
+});

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -3,19 +3,15 @@ import path from 'path';
 import { $ } from 'zx';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { beforeAll } from '@jest/globals';
-import { fileURLToPath } from 'url';
+import { getAbsolutePathsForFile } from '../src/constants';
 
-$.verbose = true;
+$.verbose = !!process.env.CI;
 process.env.IS_TEST = 'true';
 
 // eslint-disable-next-line camelcase
-const __test_filename = fileURLToPath(import.meta.url);
-// eslint-disable-next-line camelcase
-const __test_dirname = path.dirname(__test_filename);
-
+const { __dirname: __test_dirname } = getAbsolutePathsForFile(import.meta.url);
 const testDataDir = path.join(__test_dirname, './test-data/');
 
 beforeAll(() => {
-  console.log({ testDataDir });
   process.chdir(testDataDir);
 });

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -1,14 +1,21 @@
 import path from 'path';
-import { $ } from 'zx';
 
+import { $ } from 'zx';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { beforeAll } from '@jest/globals';
+import { fileURLToPath } from 'url';
 
 $.verbose = true;
 process.env.IS_TEST = 'true';
 
-const testDataDir = path.resolve('tests', './test-data/');
+// eslint-disable-next-line camelcase
+const __test_filename = fileURLToPath(import.meta.url);
+// eslint-disable-next-line camelcase
+const __test_dirname = path.dirname(__test_filename);
+
+const testDataDir = path.join(__test_dirname, './test-data/');
 
 beforeAll(() => {
+  console.log({ testDataDir });
   process.chdir(testDataDir);
 });


### PR DESCRIPTION
- It seems the reason why a good chunk of the tests that run on
the CI pipeline fail is because of the version of Ubuntu (20.0.4, focal)
that the tests run within. Ubuntu focal uses curl v7.68.x which does not include
the `--output-dir` option included in curl v7.74.x.
This is actually a compatibility issue since not many people may have the most
up-to-date curl version. There are a couple of ways to fix this but the
optimal solution would be to have the `installWithCurl` fallback to
`installWithWget` on failure since `wget`'s capabilities
(as leveraged in the source code) is more mature than curl

- Added fallback to downloading with wget if curl download fails